### PR TITLE
feat: add write permissions to media and shared paths

### DIFF
--- a/rclone_backup/config.yaml
+++ b/rclone_backup/config.yaml
@@ -19,9 +19,9 @@ panel_icon: mdi:cloud-sync
 map:
   - config:rw
   - backup:rw
-  - share:ro
+  - share:rw
   - ssl:ro
-  - media:ro
+  - media:rw
 options:
   jobs:
     - name: Sync Daily Backups


### PR DESCRIPTION
Grant write permissions on media and shared paths to allow sync back data from the cloud.