### PR TITLE
Add addon_config to rclone_backup config

### DIFF
--- a/rclone_backup/config.yaml
+++ b/rclone_backup/config.yaml
@@ -16,7 +16,7 @@ ingress: true
 panel_icon: mdi:cloud-sync
 map:
   - addons:rw
-  - addon_config: rw
+  - addon_config:rw
   - all_addon_configs:rw
   - backup:rw
   - homeassistant_config:rw

--- a/rclone_backup/config.yaml
+++ b/rclone_backup/config.yaml
@@ -16,6 +16,7 @@ ingress: true
 panel_icon: mdi:cloud-sync
 map:
   - addons:rw
+  - addon_config: rw
   - all_addon_configs:rw
   - backup:rw
   - homeassistant_config:rw


### PR DESCRIPTION
With that change I can take the rclone.conf out of the `/homeassistant/` dir and put it into `/addons_config/<slug>_hassio-rclone-config/` - that is the preferred way for Home Assistant Addon/Apps - instead of having them in `/homeassistant/`